### PR TITLE
Filter allowed values

### DIFF
--- a/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/listeners/AbstractEntitySelectionModelListener.java
+++ b/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/listeners/AbstractEntitySelectionModelListener.java
@@ -11,7 +11,10 @@ package uk.ac.manchester.cs.owl.semspreadsheets.listeners;
 import org.semanticweb.owlapi.model.OWLEntity;
 
 import uk.ac.manchester.cs.owl.semspreadsheets.model.OWLPropertyItem;
+import uk.ac.manchester.cs.owl.semspreadsheets.model.Term;
 import uk.ac.manchester.cs.owl.semspreadsheets.model.ValidationType;
+
+import java.util.List;
 
 public abstract class AbstractEntitySelectionModelListener implements
 		EntitySelectionModelListener {
@@ -31,4 +34,8 @@ public abstract class AbstractEntitySelectionModelListener implements
 		
 	}
 
+	@Override
+	public void termsChanged(List<Term> terms) {
+
+	}
 }

--- a/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/listeners/EntitySelectionModelListener.java
+++ b/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/listeners/EntitySelectionModelListener.java
@@ -10,7 +10,10 @@ package uk.ac.manchester.cs.owl.semspreadsheets.listeners;
 import org.semanticweb.owlapi.model.OWLEntity;
 
 import uk.ac.manchester.cs.owl.semspreadsheets.model.OWLPropertyItem;
+import uk.ac.manchester.cs.owl.semspreadsheets.model.Term;
 import uk.ac.manchester.cs.owl.semspreadsheets.model.ValidationType;
+
+import java.util.List;
 
 /**
  * @author Matthew Horridge
@@ -23,4 +26,6 @@ public interface EntitySelectionModelListener {
     void validationTypeChanged(ValidationType type);
     
     void selectedEntityChanged(OWLEntity entity);
+
+    void termsChanged(List<Term> terms);
 }

--- a/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/model/EntitySelectionModel.java
+++ b/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/model/EntitySelectionModel.java
@@ -34,8 +34,10 @@ public class EntitySelectionModel {
     private ValidationType validationType = ValidationType.FREETEXT; 
     
     private OWLPropertyItem owlPropertyItem;
-    
-    private boolean allowSelectionEvents = true;
+
+	private List<Term> terms; // = new ArrayList<Term>();
+
+	private boolean allowSelectionEvents = true;
 
 	private List<EntitySelectionModelListener> listeners = new ArrayList<EntitySelectionModelListener>();		
 
@@ -53,6 +55,7 @@ public class EntitySelectionModel {
         else {
             this.selectedEntity = entity;            
         }
+        terms = null;
         logger.debug("Set selected entity to "+selectedEntity.getIRI().toString());
         if (oldEntity==null ? selectedEntity!=null : !oldEntity.equals(selectedEntity)) {
         	fireSelectedEntityChanged();        	        
@@ -79,9 +82,16 @@ public class EntitySelectionModel {
 	public void setOWLPropertyItem(OWLPropertyItem owlPropertyItem) {
 		OWLPropertyItem oldItem = this.owlPropertyItem;
 		this.owlPropertyItem = owlPropertyItem;
+		this.terms = null;
 		if (oldItem==null ? this.owlPropertyItem!=null : !oldItem.equals(this.owlPropertyItem)) {
 			fireOWLPropertyChanged();			
 		}		
+	}
+
+	public List<Term> getTerms() { return terms; }
+
+	public void setTerms(List<Term> terms) {
+
 	}
     
     public void clearSelection() {

--- a/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/model/EntitySelectionModel.java
+++ b/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/model/EntitySelectionModel.java
@@ -9,6 +9,7 @@ package uk.ac.manchester.cs.owl.semspreadsheets.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.log4j.Logger;
 import org.semanticweb.owlapi.model.OWLEntity;
@@ -35,7 +36,7 @@ public class EntitySelectionModel {
     
     private OWLPropertyItem owlPropertyItem;
 
-	private List<Term> terms; // = new ArrayList<Term>();
+	private List<Term> terms;
 
 	private boolean allowSelectionEvents = true;
 
@@ -56,7 +57,7 @@ public class EntitySelectionModel {
             this.selectedEntity = entity;            
         }
         terms = null;
-        logger.debug("Set selected entity to "+selectedEntity.getIRI().toString());
+		logger.debug("Set selected entity to "+selectedEntity.getIRI().toString());
         if (oldEntity==null ? selectedEntity!=null : !oldEntity.equals(selectedEntity)) {
         	fireSelectedEntityChanged();        	        
         }        
@@ -91,7 +92,10 @@ public class EntitySelectionModel {
 	public List<Term> getTerms() { return terms; }
 
 	public void setTerms(List<Term> terms) {
-
+		if (!Objects.equals(terms, this.terms)) {
+			this.terms = terms;
+			fireTermsChanged();
+		}
 	}
     
     public void clearSelection() {
@@ -139,6 +143,15 @@ public class EntitySelectionModel {
 
 				listener.validationTypeChanged(validationType);
 
+			}
+		}
+	}
+
+	protected void fireTermsChanged() {
+		if (allowSelectionEvents) {
+			for (EntitySelectionModelListener listener : new ArrayList<EntitySelectionModelListener>(
+					listeners)) {
+				listener.termsChanged(terms);
 			}
 		}
 	}

--- a/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/model/OntologyManager.java
+++ b/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/model/OntologyManager.java
@@ -492,7 +492,13 @@ public class OntologyManager {
 	}	
 
     public void setOntologyTermValidation(Range rangeToApply,
-			ValidationType type, IRI entityIRI, OWLPropertyItem property, List<Term> terms) {
+			ValidationType type, IRI entityIRI, OWLPropertyItem property) {
+        List<Term> terms = type.getTerms(this, entityIRI);
+		getOntologyTermValidationManager().setValidation(rangeToApply, type, entityIRI, property, terms);
+	}
+
+	public void setOntologyTermValidation(Range rangeToApply,
+										  ValidationType type, IRI entityIRI, OWLPropertyItem property, List<Term> terms) {
 		getOntologyTermValidationManager().setValidation(rangeToApply, type, entityIRI, property, terms);
 	}
 

--- a/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/model/OntologyManager.java
+++ b/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/model/OntologyManager.java
@@ -492,8 +492,8 @@ public class OntologyManager {
 	}	
 
     public void setOntologyTermValidation(Range rangeToApply,
-			ValidationType type, IRI entityIRI, OWLPropertyItem property) {
-		getOntologyTermValidationManager().setValidation(rangeToApply, type, entityIRI, property);		
+			ValidationType type, IRI entityIRI, OWLPropertyItem property, List<Term> terms) {
+		getOntologyTermValidationManager().setValidation(rangeToApply, type, entityIRI, property, terms);
 	}
 
     public void unloadOntology(IRI physicalIRI) {    	

--- a/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/model/OntologyTermValidationDescriptor.java
+++ b/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/model/OntologyTermValidationDescriptor.java
@@ -66,7 +66,7 @@ public class OntologyTermValidationDescriptor implements Serializable {
         this.type = type;
         this.entityIRI = entityIRI;
 		this.propertyItem = propertyItem;
-		this.terms = terms;
+		this.terms = terms != null ? terms : type.getTerms(ontologyManager, entityIRI);
         ontologyIRI2PhysicalIRIMap = new HashMap<IRI, IRI>();
 		resolveOntologyIRIMap(entityIRI, propertyItem, ontologyManager);
     }

--- a/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/model/OntologyTermValidationDescriptor.java
+++ b/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/model/OntologyTermValidationDescriptor.java
@@ -46,8 +46,9 @@ public class OntologyTermValidationDescriptor implements Serializable {
      * @param ontologyManager
      * @param propertyItem
      */
-    public OntologyTermValidationDescriptor(OWLPropertyItem propertyItem,OntologyManager ontologyManager) { 
-    	this(ValidationType.FREETEXT,NOTHING_IRI,propertyItem,ontologyManager);    	
+    public OntologyTermValidationDescriptor(OWLPropertyItem propertyItem,OntologyManager ontologyManager) {
+    	this(ValidationType.FREETEXT,NOTHING_IRI,propertyItem,
+                ValidationType.FREETEXT.getTerms(ontologyManager, NOTHING_IRI),ontologyManager);
     }
 
     public OntologyTermValidationDescriptor(ValidationType type, IRI entityIRI, OWLPropertyItem propertyItem, Map<IRI, IRI> ontologyIRI2PhysicalIRIMap, Map<IRI, String> terms) {
@@ -61,14 +62,14 @@ public class OntologyTermValidationDescriptor implements Serializable {
         Collections.sort(this.terms);
     }
         
-    public OntologyTermValidationDescriptor(ValidationType type, IRI entityIRI, OWLPropertyItem propertyItem, OntologyManager ontologyManager) {
+    public OntologyTermValidationDescriptor(ValidationType type, IRI entityIRI, OWLPropertyItem propertyItem, List<Term> terms, OntologyManager ontologyManager) {
         this.type = type;
         this.entityIRI = entityIRI;
-		this.propertyItem = propertyItem;        
+		this.propertyItem = propertyItem;
+		this.terms = terms;
         ontologyIRI2PhysicalIRIMap = new HashMap<IRI, IRI>();
 		resolveOntologyIRIMap(entityIRI, propertyItem, ontologyManager);
-		terms = type.getTerms(ontologyManager, entityIRI);	        
-    }        
+    }
 
     private void resolveOntologyIRIMap(IRI entityIRI,
 			OWLPropertyItem propertyItem, OntologyManager ontologyManager) {

--- a/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/model/OntologyTermValidationManager.java
+++ b/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/model/OntologyTermValidationManager.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the New BSD License.
  * Please see LICENSE file that is distributed with the source code
- *  
+ *
  *******************************************************************************/
 package uk.ac.manchester.cs.owl.semspreadsheets.model;
 
@@ -36,7 +36,7 @@ public class OntologyTermValidationManager {
 	private final WorkbookManager workbookManager;
 
     public OntologyTermValidationManager(WorkbookManager workbookManager) {
-		this.workbookManager = workbookManager;		        
+		this.workbookManager = workbookManager;
     }
 
     public void addListener(OntologyTermValidationListener listener) {
@@ -49,9 +49,9 @@ public class OntologyTermValidationManager {
 
     protected void readValidationFromWorkbook() {
         OntologyTermValidationWorkbookParser parser = new OntologyTermValidationWorkbookParser(getWorkbookManager());
-        clearValidations();  
-        Collection<OntologyTermValidation> validations = parser.readOntologyTermValidations();        
-        ontologyTermValidations.addAll(validations);        
+        clearValidations();
+        Collection<OntologyTermValidation> validations = parser.readOntologyTermValidations();
+        ontologyTermValidations.addAll(validations);
         parser.clearOntologyTermValidations();
         fireValidationsChanged();
     }
@@ -78,34 +78,34 @@ public class OntologyTermValidationManager {
         if (ontologyTermValidations.removeAll(getIntersectingValidations(range))) {
             fireValidationsChanged();
         }
-    }    
-    
-    public void previewValidation(Range range, ValidationType type, IRI entityIRI, OWLPropertyItem property) {
+    }
+
+    public void previewValidation(Range range, ValidationType type, IRI entityIRI, OWLPropertyItem property, List<Term> terms) {
     	logger.debug("Previewing validation for iri "+entityIRI.toString()+", type "+type.toString()+", property = "+property);
     	List<OntologyTermValidation> previewList = new ArrayList<OntologyTermValidation>();
-    	
+
         Collection<OntologyTermValidation> intersectingValidations = getIntersectingValidations(range);
         previewList.removeAll(intersectingValidations);
-        
+
         if (!type.equals(ValidationType.FREETEXT)) {
             // Add new validation        	
-            OntologyTermValidationDescriptor descriptor = new OntologyTermValidationDescriptor(type, entityIRI,property, getOntologyManager());
-            OntologyTermValidation validation = new OntologyTermValidation(descriptor, range); 
+            OntologyTermValidationDescriptor descriptor = new OntologyTermValidationDescriptor(type, entityIRI,property, terms, getOntologyManager());
+            OntologyTermValidation validation = new OntologyTermValidation(descriptor, range);
             previewList.add(validation);
-        }        
+        }
         fireOntologyTermSelected(previewList);
     }
 
-    public void setValidation(Range range, ValidationType type, IRI entityIRI, OWLPropertyItem property) {
+    public void setValidation(Range range, ValidationType type, IRI entityIRI, OWLPropertyItem property, List<Term> terms) {
     	if (logger.isDebugEnabled()) {
     		logger.debug("Setting validation at "+range.toFixedAddress()+" type:"+type.toString()+", IRI:"+entityIRI+", property:"+property);
     	}
-    	
+
         Collection<OntologyTermValidation> intersectingValidations = getIntersectingValidations(range);
         ontologyTermValidations.removeAll(intersectingValidations);
-        
-        if (!type.equals(ValidationType.FREETEXT)) {            
-            OntologyTermValidationDescriptor descriptor = new OntologyTermValidationDescriptor(type, entityIRI, property,  getOntologyManager());
+
+        if (!type.equals(ValidationType.FREETEXT)) {
+            OntologyTermValidationDescriptor descriptor = new OntologyTermValidationDescriptor(type, entityIRI, property, terms,  getOntologyManager());
             OntologyTermValidation validation = new OntologyTermValidation(descriptor, range);
             ontologyTermValidations.add(validation);
         }
@@ -113,8 +113,8 @@ public class OntologyTermValidationManager {
         	OntologyTermValidationDescriptor descriptor = new OntologyTermValidationDescriptor(property,getOntologyManager());
             OntologyTermValidation validation = new OntologyTermValidation(descriptor, range);
             ontologyTermValidations.add(validation);
-        }        
-        
+        }
+
         fireValidationsChanged();
     }
 
@@ -126,7 +126,7 @@ public class OntologyTermValidationManager {
 
     public Collection<OntologyTermValidation> getIntersectingValidations(Range range) {
          List<OntologyTermValidation> result = new ArrayList<OntologyTermValidation>();
-        for(OntologyTermValidation validation : ontologyTermValidations) {        	
+        for(OntologyTermValidation validation : ontologyTermValidations) {
             if(validation.getRange().intersectsRange(range)) {
                 result.add(validation);
             }
@@ -172,14 +172,14 @@ public class OntologyTermValidationManager {
 
     /**
      * returns the physical IRI that the ontology was original retrieved from, according to the ontology IRI
-     * 
+     *
      * @param ontologyIRI
      * @return physicalIRI
      */
     public IRI getOntologyPhysicalIRI(IRI ontologyIRI) {
 		return getOntology2PhysicalIRIMap().get(ontologyIRI);
 	}
-    
+
     public Map<IRI, IRI> getOntology2PhysicalIRIMap() {
         Map<IRI, IRI> result = new HashMap<IRI, IRI>();
         for(OntologyTermValidation validation : ontologyTermValidations) {
@@ -201,7 +201,7 @@ public class OntologyTermValidationManager {
             }
         }
     }
-    
+
     protected void fireOntologyTermSelected(List<OntologyTermValidation> previewList) {
         for(OntologyTermValidationListener listener : new ArrayList<OntologyTermValidationListener>(listeners)) {
             try {
@@ -222,7 +222,7 @@ public class OntologyTermValidationManager {
         }
         fireValidationsChanged();
     }
-    
+
     //removes validations that match a given sheet
     public void removeValidations(Sheet sheet) {
     	for(Iterator<OntologyTermValidation> it = ontologyTermValidations.iterator(); it.hasNext(); ) {
@@ -233,14 +233,14 @@ public class OntologyTermValidationManager {
         }
         fireValidationsChanged();
     }
-    
+
     protected WorkbookManager getWorkbookManager() {
     	return workbookManager;
     }
-    
+
     protected OntologyManager getOntologyManager() {
     	return getWorkbookManager().getOntologyManager();
     }
 
-	
+
 }

--- a/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/ui/TermFilterPanel.java
+++ b/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/ui/TermFilterPanel.java
@@ -1,0 +1,167 @@
+package uk.ac.manchester.cs.owl.semspreadsheets.ui;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.*;
+import javax.swing.border.Border;
+
+import org.apache.log4j.Logger;
+import org.semanticweb.owlapi.model.IRI;
+import uk.ac.manchester.cs.owl.semspreadsheets.model.Term;
+import uk.ac.manchester.cs.owl.semspreadsheets.model.ValidationType;
+import uk.ac.manchester.cs.owl.semspreadsheets.model.WorkbookManager;
+
+import java.awt.*;
+
+/**
+ * UI Pane that allows the user to filter the allowed values in a selection.
+ *
+ * @author Mohammed Charrout
+ */
+@SuppressWarnings("serial")
+public class TermFilterPanel extends JPanel {
+
+    Logger logger = Logger.getLogger(ValidationValuesFilterPanel.class);
+
+    private WorkbookManager workbookManager;
+
+    private JList<Term> availableList;
+    private TermListModel availableListModel;
+    private JList<Term> allowedList;
+    private TermListModel allowedListModel;
+
+    private JButton addButton;
+    private JButton removeButton;
+
+    public TermFilterPanel(WorkbookManager manager) {
+        this.workbookManager = manager;
+        setLayout(new BorderLayout());
+        setBorder(BorderFactory.createEmptyBorder(7, 7, 7, 7));
+
+        createLists();
+        createButtons();
+        Border lb = BorderFactory.createLineBorder(Color.LIGHT_GRAY);
+
+        JPanel availablePanel = new JPanel();
+        availablePanel.setLayout(new BoxLayout(availablePanel, BoxLayout.Y_AXIS));
+        availablePanel.setBorder(BorderFactory.createTitledBorder(lb, "Available values"));
+        availablePanel.add(new JScrollPane(availableList));
+        add(availablePanel, BorderLayout.WEST);
+
+        JPanel buttonsPanel = new JPanel();
+        buttonsPanel.add(Box.createVerticalGlue());
+        buttonsPanel.setLayout(new BoxLayout(buttonsPanel, BoxLayout.Y_AXIS));
+        buttonsPanel.setAlignmentX(Component.CENTER_ALIGNMENT);
+        buttonsPanel.add(addButton);
+        buttonsPanel.add(removeButton);
+        buttonsPanel.add(Box.createVerticalGlue());
+        add(buttonsPanel, BorderLayout.CENTER);
+
+        JPanel allowedPanel = new JPanel();
+        allowedPanel.setLayout(new BoxLayout(allowedPanel, BoxLayout.Y_AXIS));
+        allowedPanel.setBorder(BorderFactory.createTitledBorder(lb, "Allowed values"));
+        allowedPanel.add(new JScrollPane(allowedList));
+        add(allowedPanel, BorderLayout.EAST);
+    }
+
+    private void createLists() {
+        java.util.List<Term> selectedTerms = workbookManager.getEntitySelectionModel().getTerms();
+        if (selectedTerms == null) selectedTerms = new ArrayList<>();
+        ValidationType validationType = workbookManager.getEntitySelectionModel().getValidationType();
+        IRI iri = workbookManager.getEntitySelectionModel().getSelectedEntity().getIRI();
+        java.util.List<Term> allTerms = validationType.getTerms(workbookManager.getOntologyManager(), iri);
+        java.util.List<Term> availableTerms = new ArrayList<>();
+
+        for (Term term : allTerms) {
+            if (selectedTerms.contains(term)) continue;
+            availableTerms.add(term);
+        }
+
+        allowedList = new JList<>();
+        allowedList.setCellRenderer(new TermCellRenderer());
+        allowedList.setVisibleRowCount(15);
+        allowedListModel = new TermListModel(selectedTerms);
+        allowedList.setModel(allowedListModel);
+
+        availableList = new JList<>();
+        availableList.setCellRenderer(new TermCellRenderer());
+        availableList.setVisibleRowCount(15);
+        availableListModel = new TermListModel(availableTerms);
+        availableList.setModel(availableListModel);
+    }
+
+    private void createButtons() {
+        addButton = new JButton("Add >>");
+        addButton.addActionListener(e -> {
+            java.util.List<Term> selected = availableList.getSelectedValuesList();
+            availableListModel.removeAll(selected);
+            allowedListModel.addAll(selected);
+        });
+
+        removeButton = new JButton("<< Remove");
+        removeButton.addActionListener(e -> {
+            java.util.List<Term> selected = allowedList.getSelectedValuesList();
+            allowedListModel.removeAll(selected);
+            availableListModel.addAll(selected);
+        });
+    }
+
+    public java.util.List<Term> getAllowedTerms() {
+        return allowedListModel.terms;
+    }
+
+    public static void showDialog(WorkbookFrame frame) {
+        WorkbookManager manager = frame.getWorkbookManager();
+        final TermFilterPanel panel = new TermFilterPanel(manager);
+        JOptionPane op = new JOptionPane(panel, JOptionPane.PLAIN_MESSAGE, JOptionPane.OK_CANCEL_OPTION);
+        JDialog dialog = op.createDialog(frame, "Filter list of allowed values");
+        dialog.setResizable(true);
+
+        dialog.setVisible(true);
+        if (op.getValue() != null
+                && op.getValue().equals(JOptionPane.OK_OPTION)) {
+            manager.getEntitySelectionModel().setTerms(panel.getAllowedTerms());
+            manager.previewValidation();
+        }
+    }
+
+    class TermListModel extends AbstractListModel<Term> {
+
+        private final java.util.List<Term> terms;
+
+        public TermListModel(java.util.List<Term> terms) {
+            this.terms = terms;
+        }
+
+        @Override
+        public int getSize() {
+            return terms.size();
+        }
+
+        @Override
+        public Term getElementAt(int index) {
+            return terms.get(index);
+        }
+
+        public void addAll(java.util.List<Term> terms) {
+            this.terms.addAll(terms);
+            fireContentsChanged(this, 0, getSize());
+        }
+
+        public void removeAll(List<Term> terms) {
+            this.terms.removeAll(terms);
+            fireContentsChanged(this, 0, getSize());
+        }
+    }
+
+    private class TermCellRenderer extends DefaultListCellRenderer {
+        @Override
+        public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+            JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+            Term term = (Term) value;
+            label.setText(term.getName());
+            label.setToolTipText(term.getIRI().toString());
+            return label;
+        }
+    }
+}

--- a/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/ui/TermFilterPanel.java
+++ b/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/ui/TermFilterPanel.java
@@ -65,12 +65,12 @@ public class TermFilterPanel extends JPanel {
     }
 
     private void createLists() {
-        java.util.List<Term> selectedTerms = workbookManager.getEntitySelectionModel().getTerms();
+        List<Term> selectedTerms = workbookManager.getEntitySelectionModel().getTerms();
         if (selectedTerms == null) selectedTerms = new ArrayList<>();
         ValidationType validationType = workbookManager.getEntitySelectionModel().getValidationType();
         IRI iri = workbookManager.getEntitySelectionModel().getSelectedEntity().getIRI();
-        java.util.List<Term> allTerms = validationType.getTerms(workbookManager.getOntologyManager(), iri);
-        java.util.List<Term> availableTerms = new ArrayList<>();
+        List<Term> allTerms = validationType.getTerms(workbookManager.getOntologyManager(), iri);
+        List<Term> availableTerms = new ArrayList<>();
 
         for (Term term : allTerms) {
             if (selectedTerms.contains(term)) continue;
@@ -93,24 +93,26 @@ public class TermFilterPanel extends JPanel {
     private void createButtons() {
         addButton = new JButton("Add >>");
         addButton.addActionListener(e -> {
-            java.util.List<Term> selected = availableList.getSelectedValuesList();
+            List<Term> selected = availableList.getSelectedValuesList();
             availableListModel.removeAll(selected);
             allowedListModel.addAll(selected);
         });
 
         removeButton = new JButton("<< Remove");
         removeButton.addActionListener(e -> {
-            java.util.List<Term> selected = allowedList.getSelectedValuesList();
+            List<Term> selected = allowedList.getSelectedValuesList();
             allowedListModel.removeAll(selected);
             availableListModel.addAll(selected);
         });
     }
 
-    public java.util.List<Term> getAllowedTerms() {
+    public List<Term> getAllowedTerms() {
         return allowedListModel.terms;
     }
 
     public static void showDialog(WorkbookFrame frame) {
+        final Logger logger = Logger.getLogger(ValidationValuesFilterPanel.class);
+
         WorkbookManager manager = frame.getWorkbookManager();
         final TermFilterPanel panel = new TermFilterPanel(manager);
         JOptionPane op = new JOptionPane(panel, JOptionPane.PLAIN_MESSAGE, JOptionPane.OK_CANCEL_OPTION);
@@ -120,6 +122,7 @@ public class TermFilterPanel extends JPanel {
         dialog.setVisible(true);
         if (op.getValue() != null
                 && op.getValue().equals(JOptionPane.OK_OPTION)) {
+            logger.info("Apply filter with " + panel.getAllowedTerms().size() + " items.");
             manager.getEntitySelectionModel().setTerms(panel.getAllowedTerms());
             manager.previewValidation();
         }
@@ -127,9 +130,9 @@ public class TermFilterPanel extends JPanel {
 
     class TermListModel extends AbstractListModel<Term> {
 
-        private final java.util.List<Term> terms;
+        private final List<Term> terms;
 
-        public TermListModel(java.util.List<Term> terms) {
+        public TermListModel(List<Term> terms) {
             this.terms = terms;
         }
 
@@ -143,7 +146,7 @@ public class TermFilterPanel extends JPanel {
             return terms.get(index);
         }
 
-        public void addAll(java.util.List<Term> terms) {
+        public void addAll(List<Term> terms) {
             this.terms.addAll(terms);
             fireContentsChanged(this, 0, getSize());
         }

--- a/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/ui/TermFilterPanel.java
+++ b/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/ui/TermFilterPanel.java
@@ -49,9 +49,9 @@ public class TermFilterPanel extends JPanel {
         add(availablePanel, BorderLayout.WEST);
 
         JPanel buttonsPanel = new JPanel();
-        buttonsPanel.add(Box.createVerticalGlue());
         buttonsPanel.setLayout(new BoxLayout(buttonsPanel, BoxLayout.Y_AXIS));
         buttonsPanel.setAlignmentX(Component.CENTER_ALIGNMENT);
+        buttonsPanel.add(Box.createVerticalGlue());
         buttonsPanel.add(addButton);
         buttonsPanel.add(removeButton);
         buttonsPanel.add(Box.createVerticalGlue());

--- a/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/ui/ValidationInspectorPanel.java
+++ b/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/ui/ValidationInspectorPanel.java
@@ -7,12 +7,10 @@
  *******************************************************************************/
 package uk.ac.manchester.cs.owl.semspreadsheets.ui;
 
-import java.awt.BorderLayout;
-import java.awt.Color;
-import java.awt.FlowLayout;
-import java.awt.Font;
+import java.awt.*;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
+import java.util.List;
 
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
@@ -28,10 +26,7 @@ import org.semanticweb.owlapi.model.OWLEntity;
 import uk.ac.manchester.cs.owl.semspreadsheets.listeners.AbstractEntitySelectionModelListener;
 import uk.ac.manchester.cs.owl.semspreadsheets.listeners.AbstractWorkbookManagerListener;
 import uk.ac.manchester.cs.owl.semspreadsheets.listeners.CellSelectionListener;
-import uk.ac.manchester.cs.owl.semspreadsheets.model.OWLPropertyItem;
-import uk.ac.manchester.cs.owl.semspreadsheets.model.Range;
-import uk.ac.manchester.cs.owl.semspreadsheets.model.ValidationType;
-import uk.ac.manchester.cs.owl.semspreadsheets.model.WorkbookManager;
+import uk.ac.manchester.cs.owl.semspreadsheets.model.*;
 import uk.ac.manchester.cs.owl.semspreadsheets.ui.action.ApplyValidationAction;
 
 /**
@@ -132,7 +127,10 @@ public class ValidationInspectorPanel extends JPanel {
 			@Override
 			public void selectedEntityChanged(OWLEntity entity) {				
 				updateApplyButtonState();
-			}			
+			}
+
+			@Override
+            public void termsChanged(List<Term> terms) { updateApplyButtonState(); }
 		});
 		
         typeSelectorPanel.addListItemListener(new ItemListener() {			

--- a/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/ui/ValidationInspectorPanel.java
+++ b/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/ui/ValidationInspectorPanel.java
@@ -85,7 +85,7 @@ public class ValidationInspectorPanel extends JPanel {
 		validationTypeSelectorPanel = new ValidationTypeSelectorPanel(frame.getWorkbookManager());        
         validationTypeSelectorPanel.setBorder(createTitledBorder("VALUE TYPE AND PROPERTY"));        
         
-        ValidationValuesPanel valuesPanel = new ValidationValuesPanel(frame.getWorkbookManager());
+        ValidationValuesPanel valuesPanel = new ValidationValuesPanel(frame);
         valuesPanel.setBorder(createTitledBorder("ALLOWED VALUES"));
         
         

--- a/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/ui/ValidationValuesFilterPanel.java
+++ b/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/ui/ValidationValuesFilterPanel.java
@@ -1,12 +1,13 @@
 package uk.ac.manchester.cs.owl.semspreadsheets.ui;
 
+import org.semanticweb.owlapi.model.IRI;
 import uk.ac.manchester.cs.owl.semspreadsheets.listeners.OntologyTermValidationListener;
-import uk.ac.manchester.cs.owl.semspreadsheets.model.OntologyTermValidation;
-import uk.ac.manchester.cs.owl.semspreadsheets.model.Range;
-import uk.ac.manchester.cs.owl.semspreadsheets.model.WorkbookManager;
+import uk.ac.manchester.cs.owl.semspreadsheets.model.*;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.util.Collection;
@@ -38,15 +39,22 @@ public class ValidationValuesFilterPanel extends JPanel {
                 Object source = e.getItemSelectable();
                 if (source == checkBox) {
                     setEnabledStatus();
+                    updateEntityModel();
                 }
             }
         });
-        add(checkBox, BorderLayout.WEST);
+//        add(checkBox, BorderLayout.WEST);
 
-        add(Box.createHorizontalGlue());
+//        add(Box.createHorizontalGlue());
 
         button = new JButton("Filter");
-        button.addActionListener(e -> TermFilterPanel.showDialog(workbookFrame));
+        button.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                TermFilterPanel.showDialog(workbookFrame);
+                updateEntityModel();
+            }
+        });
         add(button, BorderLayout.EAST);
 
         workbookManager.getOntologyManager().addListener(new OntologyTermValidationListener() {
@@ -72,12 +80,25 @@ public class ValidationValuesFilterPanel extends JPanel {
             checkBox.setEnabled(false);
         } else {
             checkBox.setEnabled(true);
-            button.setEnabled(checkBox.isSelected());
+            button.setEnabled(true);
+//            button.setEnabled(checkBox.isSelected());
         }
         checkBox.setSelected(checkBox.isSelected() && button.isEnabled());
     }
 
     private void updateEntityModel() {
-
+        Boolean checkBoxSelected = checkBox.isSelected();
+        checkBoxSelected = true;
+        if (checkBoxSelected) {
+            List<Term> terms = workbookManager.getEntitySelectionModel().getTerms();
+            if (terms == null) {
+                IRI iri = workbookManager.getEntitySelectionModel().getSelectedEntity().getIRI();
+                ValidationType type = workbookManager.getEntitySelectionModel().getValidationType();
+                terms = type.getTerms(workbookManager.getOntologyManager(), iri);
+            }
+            workbookManager.getEntitySelectionModel().setTerms(terms);
+        } else {
+            workbookManager.getEntitySelectionModel().setTerms(null);
+        }
     }
 }

--- a/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/ui/ValidationValuesFilterPanel.java
+++ b/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/ui/ValidationValuesFilterPanel.java
@@ -1,0 +1,83 @@
+package uk.ac.manchester.cs.owl.semspreadsheets.ui;
+
+import uk.ac.manchester.cs.owl.semspreadsheets.listeners.OntologyTermValidationListener;
+import uk.ac.manchester.cs.owl.semspreadsheets.model.OntologyTermValidation;
+import uk.ac.manchester.cs.owl.semspreadsheets.model.Range;
+import uk.ac.manchester.cs.owl.semspreadsheets.model.WorkbookManager;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * UI Pane
+ *
+ * @author Mohammed Charrout
+ */
+@SuppressWarnings("serial")
+public class ValidationValuesFilterPanel extends JPanel {
+
+    private WorkbookManager workbookManager;
+
+    private boolean valuesAvailable;
+
+    private JCheckBox checkBox;
+    private JButton button;
+
+    public ValidationValuesFilterPanel(WorkbookFrame workbookFrame) {
+        this.workbookManager = workbookFrame.getWorkbookManager();
+        setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
+
+        checkBox = new JCheckBox("Enable filter");
+        checkBox.addItemListener(new ItemListener() {
+            @Override
+            public void itemStateChanged(ItemEvent e) {
+                Object source = e.getItemSelectable();
+                if (source == checkBox) {
+                    setEnabledStatus();
+                }
+            }
+        });
+        add(checkBox, BorderLayout.WEST);
+
+        add(Box.createHorizontalGlue());
+
+        button = new JButton("Filter");
+        button.addActionListener(e -> TermFilterPanel.showDialog(workbookFrame));
+        add(button, BorderLayout.EAST);
+
+        workbookManager.getOntologyManager().addListener(new OntologyTermValidationListener() {
+            @Override
+            public void validationsChanged() {
+                Range range = workbookManager.getSelectionModel().getSelectedRange();
+                Collection<OntologyTermValidation> validations = workbookManager.getOntologyManager().getContainingOntologyTermValidations(range);
+                valuesAvailable = !validations.isEmpty();
+                setEnabledStatus();
+            }
+
+            @Override
+            public void ontologyTermSelected(List<OntologyTermValidation> previewValidations) {
+                valuesAvailable = !previewValidations.isEmpty();
+                setEnabledStatus();
+            }
+        });
+    }
+
+    private void setEnabledStatus() {
+        if (!valuesAvailable) {
+            button.setEnabled(false);
+            checkBox.setEnabled(false);
+        } else {
+            checkBox.setEnabled(true);
+            button.setEnabled(checkBox.isSelected());
+        }
+        checkBox.setSelected(checkBox.isSelected() && button.isEnabled());
+    }
+
+    private void updateEntityModel() {
+
+    }
+}

--- a/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/ui/ValidationValuesPanel.java
+++ b/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/ui/ValidationValuesPanel.java
@@ -45,16 +45,12 @@ public class ValidationValuesPanel extends JPanel {
         this.workbookManager = frame.getWorkbookManager();
         setLayout(new BorderLayout());
 
-        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
-        JButton filterButton = new JButton("Filter");
-        filterButton.addActionListener(e -> TermFilterPanel.showDialog(frame));
-        buttonPanel.add(filterButton);
-        add(buttonPanel, BorderLayout.NORTH);
-
         createTermList();
         JScrollPane sp = new JScrollPane(termList);
         add(sp, BorderLayout.CENTER);
         sp.setBorder(BorderFactory.createLineBorder(Color.LIGHT_GRAY));
+
+        add(new ValidationValuesFilterPanel(frame), BorderLayout.SOUTH);
 
         workbookManager.getSelectionModel().addCellSelectionListener(new CellSelectionListener() {
             public void selectionChanged(Range range) {

--- a/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/ui/ValidationValuesPanel.java
+++ b/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/ui/ValidationValuesPanel.java
@@ -8,14 +8,15 @@
 package uk.ac.manchester.cs.owl.semspreadsheets.ui;
 
 import java.awt.*;
-import java.util.Collection;
+import java.util.*;
 import java.util.List;
-import java.util.TreeSet;
 
 import javax.swing.*;
 
+import org.apache.log4j.Logger;
 import org.semanticweb.owlapi.model.IRI;
 
+import uk.ac.manchester.cs.owl.semspreadsheets.listeners.AbstractEntitySelectionModelListener;
 import uk.ac.manchester.cs.owl.semspreadsheets.listeners.CellSelectionListener;
 import uk.ac.manchester.cs.owl.semspreadsheets.listeners.OntologyTermValidationListener;
 import uk.ac.manchester.cs.owl.semspreadsheets.model.OntologyTermValidation;
@@ -32,6 +33,8 @@ import uk.ac.manchester.cs.owl.semspreadsheets.model.WorkbookManager;
  */
 @SuppressWarnings("serial")
 public class ValidationValuesPanel extends JPanel {
+
+    Logger logger = Logger.getLogger(ValidationValuesPanel.class);
 
     private WorkbookManager workbookManager;
 
@@ -69,6 +72,13 @@ public class ValidationValuesPanel extends JPanel {
                     List<OntologyTermValidation> previewList) {
                 updateFromPreviewList(previewList);
 
+            }
+        });
+
+        workbookManager.getEntitySelectionModel().addListener(new AbstractEntitySelectionModelListener() {
+            @Override
+            public void termsChanged(List<Term> terms) {
+                updateFromSelectionModel(terms);
             }
         });
     }
@@ -131,6 +141,21 @@ public class ValidationValuesPanel extends JPanel {
             }
         }
         termList.setListData(listData.toArray(new ValueListItem[listData.size()]));
+    }
+
+    private void updateFromSelectionModel(List<Term> terms) {
+        termList.setListData(new ValueListItem[0]);
+
+        ValidationType type = workbookManager.getEntitySelectionModel().getValidationType();
+        List<ValueListItem> listItems = new ArrayList<>();
+
+        if (terms != null) {
+            for (Term term : terms) {
+                listItems.add(new ValueListItem(term, type));
+            }
+        }
+
+        termList.setListData(listItems.toArray(new ValueListItem[listItems.size()]));
     }
 
     private class ValueListItemCellRenderer extends DefaultListCellRenderer {

--- a/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/ui/ValidationValuesPanel.java
+++ b/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/ui/ValidationValuesPanel.java
@@ -3,27 +3,16 @@
  *
  * Licensed under the New BSD License.
  * Please see LICENSE file that is distributed with the source code
- *  
+ *
  *******************************************************************************/
 package uk.ac.manchester.cs.owl.semspreadsheets.ui;
 
-import java.awt.BorderLayout;
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Font;
-import java.awt.Graphics;
-import java.awt.Rectangle;
+import java.awt.*;
 import java.util.Collection;
 import java.util.List;
 import java.util.TreeSet;
 
-import javax.swing.BorderFactory;
-import javax.swing.DefaultListCellRenderer;
-import javax.swing.JLabel;
-import javax.swing.JList;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.ToolTipManager;
+import javax.swing.*;
 
 import org.semanticweb.owlapi.model.IRI;
 
@@ -37,7 +26,7 @@ import uk.ac.manchester.cs.owl.semspreadsheets.model.WorkbookManager;
 
 /**
  * UI Pane that shows the available terms for the selected Type.
- * 
+ *
  * @author Stuart Owen
  * @author Matthew Horridge
  */
@@ -52,41 +41,48 @@ public class ValidationValuesPanel extends JPanel {
 
     private static final String EMPTY_VALIDATION = "None";
 
-    public ValidationValuesPanel(WorkbookManager manager) {
-        this.workbookManager = manager;
+    public ValidationValuesPanel(WorkbookFrame frame) {
+        this.workbookManager = frame.getWorkbookManager();
         setLayout(new BorderLayout());
+
+        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        JButton filterButton = new JButton("Filter");
+        filterButton.addActionListener(e -> TermFilterPanel.showDialog(frame));
+        buttonPanel.add(filterButton);
+        add(buttonPanel, BorderLayout.NORTH);
+
         createTermList();
         JScrollPane sp = new JScrollPane(termList);
-        
         add(sp, BorderLayout.CENTER);
         sp.setBorder(BorderFactory.createLineBorder(Color.LIGHT_GRAY));
+
         workbookManager.getSelectionModel().addCellSelectionListener(new CellSelectionListener() {
             public void selectionChanged(Range range) {
                 updateFromModel(range);
             }
         });
-        
+
         workbookManager.getOntologyManager().addListener(new OntologyTermValidationListener() {
             @Override
-        	public void validationsChanged() {
+            public void validationsChanged() {
                 updateFromModel(workbookManager.getSelectionModel().getSelectedRange());
-            }			
+            }
 
-			@Override
-			public void ontologyTermSelected(
-					List<OntologyTermValidation> previewList) {
-				updateFromPreviewList(previewList);
-				
-			}
-        });        
+            @Override
+            public void ontologyTermSelected(
+                    List<OntologyTermValidation> previewList) {
+                updateFromPreviewList(previewList);
+
+            }
+        });
     }
 
-	private void createTermList() {
-		termList = new JList<ValueListItem>() {
-            
+    private void createTermList() {
+        termList = new JList<ValueListItem>() {
+
             private Font nowValuesSpecifiedFont = new Font("Lucida Grande", Font.BOLD, 14);
 
-             @Override
+            @Override
             protected void paintComponent(Graphics g) {
                 super.paintComponent(g);
                 if (termList.getModel().getSize() == 0) {
@@ -94,7 +90,7 @@ public class ValidationValuesPanel extends JPanel {
                     Range selRange = workbookManager.getSelectionModel().getSelectedRange();
                     if (selRange.isCellSelection()) {
                         Collection<OntologyTermValidation> validations = workbookManager.getOntologyManager().getContainingOntologyTermValidations(selRange);
-                        if(!validations.isEmpty()) {
+                        if (!validations.isEmpty()) {
                             msg = EMPTY_VALIDATION;
                         }
                     }
@@ -112,29 +108,29 @@ public class ValidationValuesPanel extends JPanel {
         };
         termList.setCellRenderer(new ValueListItemCellRenderer());
         ToolTipManager.sharedInstance().registerComponent(termList);
-	}
+    }
 
     protected void updateFromPreviewList(
-			List<OntologyTermValidation> previewList) {
-    	TreeSet<ValueListItem> listData = new TreeSet<ValueListItem>();
-    	for(OntologyTermValidation validation : previewList) {
-            for(Term term : validation.getValidationDescriptor().getTerms()) {
+            List<OntologyTermValidation> previewList) {
+        TreeSet<ValueListItem> listData = new TreeSet<ValueListItem>();
+        for (OntologyTermValidation validation : previewList) {
+            for (Term term : validation.getValidationDescriptor().getTerms()) {
                 listData.add(new ValueListItem(term, validation.getValidationDescriptor().getType()));
             }
         }
-        termList.setListData(listData.toArray(new ValueListItem[listData.size()]));		
-	}
+        termList.setListData(listData.toArray(new ValueListItem[listData.size()]));
+    }
 
-	private void updateFromModel(Range range) {		
-        termList.setListData(new ValueListItem [0]);
-        
-        if(!range.isCellSelection()) {
+    private void updateFromModel(Range range) {
+        termList.setListData(new ValueListItem[0]);
+
+        if (!range.isCellSelection()) {
             return;
         }
         Collection<OntologyTermValidation> validations = workbookManager.getOntologyManager().getContainingOntologyTermValidations(range);
         TreeSet<ValueListItem> listData = new TreeSet<ValueListItem>();
-        for(OntologyTermValidation validation : validations) {
-            for(Term term : validation.getValidationDescriptor().getTerms()) {
+        for (OntologyTermValidation validation : validations) {
+            for (Term term : validation.getValidationDescriptor().getTerms()) {
                 listData.add(new ValueListItem(term, validation.getValidationDescriptor().getType()));
             }
         }
@@ -146,7 +142,7 @@ public class ValidationValuesPanel extends JPanel {
         @Override
         public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
             JLabel label = (JLabel) super.getListCellRendererComponent(list, ((ValueListItem) value), index, isSelected, cellHasFocus);
-            ValueListItem item = (ValueListItem) value;            
+            ValueListItem item = (ValueListItem) value;
             ValidationEntityType<?> entityType = item.getType().getEntityType();
             label.setIcon(Icons.getOWLEntityIcon(entityType));
             label.setToolTipText(item.getEntityIRI().toString());
@@ -157,7 +153,7 @@ public class ValidationValuesPanel extends JPanel {
     private class ValueListItem implements Comparable<ValueListItem> {
 
         private Term term;
-                
+
 
         private ValidationType type;
 
@@ -170,21 +166,21 @@ public class ValidationValuesPanel extends JPanel {
         public String toString() {
             return getName();
         }
-        
+
         public String getName() {
-        	return term.getFormattedName();
+            return term.getFormattedName();
         }
-        
+
         public IRI getEntityIRI() {
-        	return term.getIRI();
+            return term.getIRI();
         }
-        
+
         public ValidationType getType() {
             return type;
         }
-        
+
         protected Term getTerm() {
-        	return term;
+            return term;
         }
 
         public int compareTo(ValueListItem o) {
@@ -193,5 +189,4 @@ public class ValidationValuesPanel extends JPanel {
     }
 
 
-    
 }

--- a/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/ui/action/SheetCellPasteAction.java
+++ b/src/main/java/uk/ac/manchester/cs/owl/semspreadsheets/ui/action/SheetCellPasteAction.java
@@ -14,15 +14,12 @@ import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.io.IOException;
+import java.util.List;
 import java.util.StringTokenizer;
 
 import org.apache.log4j.Logger;
 
-import uk.ac.manchester.cs.owl.semspreadsheets.model.Cell;
-import uk.ac.manchester.cs.owl.semspreadsheets.model.OntologyTermValidationDescriptor;
-import uk.ac.manchester.cs.owl.semspreadsheets.model.Range;
-import uk.ac.manchester.cs.owl.semspreadsheets.model.Sheet;
-import uk.ac.manchester.cs.owl.semspreadsheets.model.WorkbookManager;
+import uk.ac.manchester.cs.owl.semspreadsheets.model.*;
 import uk.ac.manchester.cs.owl.semspreadsheets.model.change.SetCellValue;
 
 /**
@@ -109,7 +106,8 @@ public class SheetCellPasteAction extends SelectedCellsAction {
 			OntologyTermValidationDescriptor descriptor) {
 		getWorkbookManager().removeValidations(range);
 		if (descriptor!=null) {			
-			getWorkbookManager().setValidationAt(range,descriptor.getType(), descriptor.getEntityIRI(), descriptor.getOWLPropertyItem());
+			getWorkbookManager().setValidationAt(range,descriptor.getType(), descriptor.getEntityIRI(),
+					descriptor.getOWLPropertyItem(), (List<Term>) descriptor.getTerms());
 		}
 	}
 	

--- a/src/test/java/uk/ac/manchester/cs/owl/semspreadsheets/DummyEntitySelectionModelListener.java
+++ b/src/test/java/uk/ac/manchester/cs/owl/semspreadsheets/DummyEntitySelectionModelListener.java
@@ -4,7 +4,10 @@ import org.semanticweb.owlapi.model.OWLEntity;
 
 import uk.ac.manchester.cs.owl.semspreadsheets.listeners.EntitySelectionModelListener;
 import uk.ac.manchester.cs.owl.semspreadsheets.model.OWLPropertyItem;
+import uk.ac.manchester.cs.owl.semspreadsheets.model.Term;
 import uk.ac.manchester.cs.owl.semspreadsheets.model.ValidationType;
+
+import java.util.List;
 
 public class DummyEntitySelectionModelListener implements EntitySelectionModelListener {
 
@@ -23,6 +26,9 @@ public class DummyEntitySelectionModelListener implements EntitySelectionModelLi
 	}
 
 
+	public boolean isTermsChanged() { return termsChanged; }
+
+
 	public OWLPropertyItem getSelectedProperty() {
 		return selectedProperty;
 	}
@@ -38,6 +44,9 @@ public class DummyEntitySelectionModelListener implements EntitySelectionModelLi
 	}
 
 
+	public List<Term> getSelectedTerms() { return selectedTerms; }
+
+
 	public DummyEntitySelectionModelListener() {
 		reset();
 	}
@@ -45,18 +54,22 @@ public class DummyEntitySelectionModelListener implements EntitySelectionModelLi
 	private boolean owlPropertyChanged;
 	private boolean validationTypeChanged;
 	private boolean selectedEntityChanged;
+	private boolean termsChanged;
 	
 	private OWLPropertyItem selectedProperty;
 	private OWLEntity selectedEntity;
 	private ValidationType selectedValidationType;
+	private List<Term> selectedTerms;
 	
 	public void reset() {
 		owlPropertyChanged=false;
 		validationTypeChanged=false;
 		selectedEntityChanged=false;
+		termsChanged=false;
 		selectedProperty=null;
 		selectedEntity=null;
 		selectedValidationType=null;
+		selectedTerms=null;
 	}
 	
 	
@@ -76,6 +89,12 @@ public class DummyEntitySelectionModelListener implements EntitySelectionModelLi
 	public void selectedEntityChanged(OWLEntity entity) {
 		selectedEntity=entity;
 		selectedEntityChanged=true;		
+	}
+
+	@Override
+	public void termsChanged(List<Term> terms) {
+		selectedTerms=terms;
+		termsChanged=true;
 	}
 
 }

--- a/src/test/java/uk/ac/manchester/cs/owl/semspreadsheets/model/OntologyManagerTest.java
+++ b/src/test/java/uk/ac/manchester/cs/owl/semspreadsheets/model/OntologyManagerTest.java
@@ -406,7 +406,7 @@ public class OntologyManagerTest {
 		Sheet sheet = workbookManager.getWorkbook().getSheet(0);
 		Range range  = new Range(sheet,1,1,1,1);
 		assertTrue(ontologyManager.getOntologyIRIs().isEmpty());
-		ontologyManager.setOntologyTermValidation(range, ValidationType.SUBCLASSES, IRI.create("http://www.mygrid.org.uk/ontology/JERMOntology#AssayType"), null);
+		ontologyManager.setOntologyTermValidation(range, ValidationType.SUBCLASSES, IRI.create("http://www.mygrid.org.uk/ontology/JERMOntology#AssayType"), null, null);
 		assertEquals(1,ontologyManager.getOntologyIRIs().size());
 		assertTrue(ontologyManager.getOntologyIRIs().contains(IRI.create("http://www.mygrid.org.uk/ontology/JERMOntology")));
 		

--- a/src/test/java/uk/ac/manchester/cs/owl/semspreadsheets/model/OntologyTermValidationDescriptorTest.java
+++ b/src/test/java/uk/ac/manchester/cs/owl/semspreadsheets/model/OntologyTermValidationDescriptorTest.java
@@ -14,6 +14,8 @@ import org.semanticweb.owlapi.reasoner.impl.NodeFactory;
 
 import uk.ac.manchester.cs.owl.semspreadsheets.DocumentsCatalogue;
 
+import java.util.List;
+
 public class OntologyTermValidationDescriptorTest {
 	
 	private OntologyManager ontManager;
@@ -29,7 +31,7 @@ public class OntologyTermValidationDescriptorTest {
 	@Test @Ignore("Dependent ontology contains an invalid import. Ontology needs fixing to no longer be reliant on external resources")
 	public void testOntologyIRIsWithOWLThing() throws Exception {		
 		IRI owlThingEntity = NodeFactory.getOWLClassTopNode().getEntities().iterator().next().getIRI();
-		OntologyTermValidationDescriptor descriptor = new OntologyTermValidationDescriptor(ValidationType.SUBCLASSES,owlThingEntity,null,ontManager);
+		OntologyTermValidationDescriptor descriptor = new OntologyTermValidationDescriptor(ValidationType.SUBCLASSES,owlThingEntity,null,null,ontManager);
 		assertEquals(3,descriptor.getOntologyIRIs().size());
 		assertTrue(descriptor.getOntologyIRIs().contains(IRI.create("http://www.mygrid.org.uk/ontology/JERMOntology")));
 		assertTrue(descriptor.getOntologyIRIs().contains(IRI.create("http://www.co-ode.org/ontologies/meta/2005/06/15/meta.owl")));
@@ -41,7 +43,7 @@ public class OntologyTermValidationDescriptorTest {
 		OntologyManager man = new WorkbookManager().getOntologyManager();
 		man.loadOntology(DocumentsCatalogue.rdfSchemaOntologyURI());
 		IRI owlThingEntity = NodeFactory.getOWLClassTopNode().getEntities().iterator().next().getIRI();
-		OntologyTermValidationDescriptor descriptor = new OntologyTermValidationDescriptor(ValidationType.SUBCLASSES,owlThingEntity,null,man);
+		OntologyTermValidationDescriptor descriptor = new OntologyTermValidationDescriptor(ValidationType.SUBCLASSES,owlThingEntity,null,null,man);
 		assertEquals(1,descriptor.getOntologyIRIs().size());
 		assertTrue(descriptor.getOntologyIRIs().contains(IRI.create(DocumentsCatalogue.rdfSchemaOntologyURI())));		
 	}
@@ -68,12 +70,14 @@ public class OntologyTermValidationDescriptorTest {
 	
 	@Test
 	public void testEntityNoProperty() throws Exception {		
-		
+
+		ValidationType validationType = ValidationType.INDIVIDUALS;
 		IRI entityIRI = IRI.create("http://www.mygrid.org.uk/ontology/JERMOntology#Project");
+		List<Term> terms = validationType.getTerms(ontManager, entityIRI);
 		
-		OntologyTermValidationDescriptor descriptor = new OntologyTermValidationDescriptor(ValidationType.INDIVIDUALS,entityIRI,null,ontManager);
+		OntologyTermValidationDescriptor descriptor = new OntologyTermValidationDescriptor(validationType,entityIRI,null,terms,ontManager);
 		
-		assertEquals(ValidationType.INDIVIDUALS,descriptor.getType());
+		assertEquals(validationType,descriptor.getType());
 		assertNull(descriptor.getOWLPropertyItem());
 		assertEquals(13,descriptor.getTerms().size());
 		assertEquals(IRI.create("http://www.mygrid.org.uk/ontology/JERMOntology#Project"),descriptor.getEntityIRI());		
@@ -88,13 +92,14 @@ public class OntologyTermValidationDescriptorTest {
 	
 	@Test
 	public void testEntityAndProperty() throws Exception {		
-		
+		ValidationType validationType = ValidationType.SUBCLASSES;
 		OWLPropertyItem property = new OWLPropertyItem(IRI.create("http://mygrid/JERMOntology#fishing"),OWLPropertyType.DATA_PROPERTY);
 		IRI entityIRI = IRI.create("http://www.mygrid.org.uk/ontology/JERMOntology#AssayType");
+		List<Term> terms = validationType.getTerms(ontManager, entityIRI);
 		
-		OntologyTermValidationDescriptor descriptor = new OntologyTermValidationDescriptor(ValidationType.SUBCLASSES,entityIRI,property,ontManager);
+		OntologyTermValidationDescriptor descriptor = new OntologyTermValidationDescriptor(validationType,entityIRI,property,terms,ontManager);
 		
-		assertEquals(ValidationType.SUBCLASSES,descriptor.getType());
+		assertEquals(validationType,descriptor.getType());
 		assertEquals(65,descriptor.getTerms().size());
 		assertEquals(property,descriptor.getOWLPropertyItem());
 		

--- a/src/test/java/uk/ac/manchester/cs/owl/semspreadsheets/model/OntologyTermValidationWorkbookParserTest.java
+++ b/src/test/java/uk/ac/manchester/cs/owl/semspreadsheets/model/OntologyTermValidationWorkbookParserTest.java
@@ -28,32 +28,32 @@ public class OntologyTermValidationWorkbookParserTest {
 		ontManager.loadOntology(DocumentsCatalogue.jermOntologyURI());
 		parser = new OntologyTermValidationWorkbookParser(manager);
 	}
-	
+
 	@Test
 	public void testWritingFreeTextProperty() throws Exception {
 		assertEquals(1,manager.getWorkbook().getSheets().size());
 		assertEquals(1,manager.getWorkbook().getVisibleSheets().size());
-		
-		Collection<OntologyTermValidation> validations = createFreeTextValidations();				
-		
+
+		Collection<OntologyTermValidation> validations = createFreeTextValidations();
+
 		Collection<Validation> sheetValidations = manager.getWorkbook().getSheet(0).getValidations();
 		assertEquals(0,sheetValidations.size());
-		
-		parser.writeOntologyTermValidations(validations);		
-		
+
+		parser.writeOntologyTermValidations(validations);
+
 		assertEquals(2,manager.getWorkbook().getSheets().size());
 		assertEquals(1,manager.getWorkbook().getVisibleSheets().size());
 		Sheet validationSheet = manager.getWorkbook().getSheet(1);
 		assertTrue(validationSheet.isVeryHidden());
 		assertEquals("wksowlv0",validationSheet.getName());
-		
+
 		assertEquals("FREETEXT",validationSheet.getCellAt(0,0).getValue());
 		assertEquals("<http://www.w3.org/2002/07/owl#Nothing>",validationSheet.getCellAt(1,0).getValue());
 		assertEquals("ontology",validationSheet.getCellAt(0,1).getValue());
 		assertEquals("<http://www.mygrid.org.uk/ontology/JERMOntology>",validationSheet.getCellAt(1,1).getValue());
 		assertEquals("<"+DocumentsCatalogue.jermOntologyURI().toString()+">",validationSheet.getCellAt(2,1).getValue());
 		assertNull(validationSheet.getCellAt(1,2));
-		
+
 		sheetValidations = manager.getWorkbook().getSheet(0).getValidations();
 		assertEquals(1,sheetValidations.size());
 		Validation v = sheetValidations.iterator().next();
@@ -65,43 +65,43 @@ public class OntologyTermValidationWorkbookParserTest {
 		assertTrue(v.isLiteralValidation());
 		assertFalse(v.isDataValidation());
 	}
-	
+
 	private Collection<OntologyTermValidation> createFreeTextValidations() {
 		Sheet sheet = manager.getWorkbook().getSheet(0);
 		assertNotNull(sheet);
 		assertEquals("Sheet0",sheet.getName());
-		OWLPropertyItem property = new OWLPropertyItem(IRI.create("http://www.mygrid.org.uk/ontology/JERMOntology#hasCharacteristics"),OWLPropertyType.OBJECT_PROPERTY);		
+		OWLPropertyItem property = new OWLPropertyItem(IRI.create("http://www.mygrid.org.uk/ontology/JERMOntology#hasCharacteristics"),OWLPropertyType.OBJECT_PROPERTY);
 		assertNotNull(property);
-		
+
 		Cell cell = sheet.addCellAt(2, 1);
 		assertNotNull(cell);
 		Range range = new Range(sheet, cell);
-		
+
 		OntologyTermValidationDescriptor descriptor = new OntologyTermValidationDescriptor(property, ontManager);
 		OntologyTermValidation validation = new OntologyTermValidation(descriptor, range);
 		ArrayList<OntologyTermValidation> validations = new ArrayList<OntologyTermValidation>();
 		validations.add(validation);
 		return validations;
 	}
-	
+
 	@Test
 	public void testWritingDataSelectionValidation() throws Exception {
-						
+
 		assertEquals(1,manager.getWorkbook().getSheets().size());
 		assertEquals(1,manager.getWorkbook().getVisibleSheets().size());
-		
-		
+
+
 		Collection<Validation> sheetValidations = manager.getWorkbook().getSheet(0).getValidations();
 		assertEquals(0,sheetValidations.size());
 		Collection<OntologyTermValidation> validations = createDataSelectionValidation();
 		parser.writeOntologyTermValidations(validations);
-		
+
 		assertEquals(2,manager.getWorkbook().getSheets().size());
 		assertEquals(1,manager.getWorkbook().getVisibleSheets().size());
 		Sheet validationSheet = manager.getWorkbook().getSheet(1);
 		assertTrue(validationSheet.isVeryHidden());
 		assertEquals("wksowlv0",validationSheet.getName());
-		
+
 		assertEquals("INDIVIDUALS",validationSheet.getCellAt(0,0).getValue());
 		assertEquals("<http://www.mygrid.org.uk/ontology/JERMOntology#Project>",validationSheet.getCellAt(1,0).getValue());
 		assertEquals("ontology",validationSheet.getCellAt(0,1).getValue());
@@ -110,7 +110,7 @@ public class OntologyTermValidationWorkbookParserTest {
 		assertEquals("<http://www.mygrid.org.uk/ontology/JERMOntology#BaCell>",validationSheet.getCellAt(0, 2).getValue());
 		assertEquals("BaCell",validationSheet.getCellAt(1, 2).getValue());
 		sheetValidations = manager.getWorkbook().getSheet(0).getValidations();
-		
+
 		Validation v = sheetValidations.iterator().next();
 		assertEquals(1,sheetValidations.size());
 		Sheet sheet = manager.getWorkbook().getSheet(0);
@@ -121,25 +121,30 @@ public class OntologyTermValidationWorkbookParserTest {
 		assertTrue(v.isDataValidation());
 		assertFalse(v.isLiteralValidation());
 	}
-	
+
 	private Collection<OntologyTermValidation> createDataSelectionValidation() throws Exception {
 		Sheet sheet = manager.getWorkbook().getSheet(0);
 		assertNotNull(sheet);
 		assertEquals("Sheet0",sheet.getName());
 		OWLPropertyItem property = new OWLPropertyItem(IRI.create("http://www.mygrid.org.uk/ontology/JERMOntology#hasCharacteristics"),OWLPropertyType.OBJECT_PROPERTY);
 		assertNotNull(property);
-		
+
 		Cell cell = sheet.addCellAt(2, 1);
 		assertNotNull(cell);
-		Range range = new Range(sheet, cell);		
-		
-		OntologyTermValidationDescriptor descriptor = new OntologyTermValidationDescriptor(ValidationType.INDIVIDUALS,IRI.create("http://www.mygrid.org.uk/ontology/JERMOntology#Project"),property,ontManager);
+		Range range = new Range(sheet, cell);
+
+
+		ValidationType validationType = ValidationType.INDIVIDUALS;
+		IRI iri = IRI.create("http://www.mygrid.org.uk/ontology/JERMOntology#Project");
+
+		OntologyTermValidationDescriptor descriptor = new OntologyTermValidationDescriptor(validationType,iri,property,
+				validationType.getTerms(ontManager, iri), ontManager);
 		OntologyTermValidation validation = new OntologyTermValidation(descriptor, range);
 		ArrayList<OntologyTermValidation> validations = new ArrayList<OntologyTermValidation>();
 		validations.add(validation);
 		return validations;
 	}
-	
+
 	@Test
 	public void testParseDataSelectionValidation() throws Exception {
 		Collection<OntologyTermValidation> validations = createDataSelectionValidation();
@@ -156,14 +161,14 @@ public class OntologyTermValidationWorkbookParserTest {
 		assertEquals(1,v.getValidationDescriptor().getOntologyIRIs().size());
 		assertTrue(v.getValidationDescriptor().getOntologyIRIs().contains(IRI.create("http://www.mygrid.org.uk/ontology/JERMOntology")));
 	}
-	
+
 	@Test
-	public void testParseFreeTextProperty() throws Exception {		
+	public void testParseFreeTextProperty() throws Exception {
 		Collection<OntologyTermValidation> validations = createFreeTextValidations();
 		parser.writeOntologyTermValidations(validations);
 		validations = parser.readOntologyTermValidations();
 		assertEquals(1,validations.size());
-		OntologyTermValidation v = validations.iterator().next();		
+		OntologyTermValidation v = validations.iterator().next();
 		assertEquals(new Range(manager.getWorkbook().getSheet(0),2,1,2,1),v.getRange());
 		assertEquals("http://www.w3.org/2002/07/owl#Nothing",v.getValidationDescriptor().getEntityIRI().toString());
 		assertEquals(ValidationType.FREETEXT,v.getValidationDescriptor().getType());
@@ -172,34 +177,34 @@ public class OntologyTermValidationWorkbookParserTest {
 		assertEquals(1,v.getValidationDescriptor().getOntologyIRIs().size());
 		assertTrue(v.getValidationDescriptor().getOntologyIRIs().contains(IRI.create("http://www.mygrid.org.uk/ontology/JERMOntology")));
 	}
-	
+
 	@Test //covers an error when trying to read the data validations, where it detects a formula but it is blank. Possibly caused by macros.
 	public void testParseValidationsWithBlankFormulaXLS() throws Exception {
-		Workbook book = manager.loadWorkbook(DocumentsCatalogue.prideTemplateEmptyWorkbookURI());		
+		Workbook book = manager.loadWorkbook(DocumentsCatalogue.prideTemplateEmptyWorkbookURI());
 		assertEquals(15,book.getSheets().size());
 		assertEquals("Introduction",book.getSheet(0).getName());
 		Collection<OntologyTermValidation> validations = parser.readOntologyTermValidations();
 		assertEquals(0,validations.size());
 	}
-	
+
 	@Test //same as test above but for xlsx
 	public void testParseValidationsWithBlankFormulaXLSX() throws Exception {
-		Workbook book = manager.loadWorkbook(DocumentsCatalogue.prideTemplateEmptyWorkbookXLSXURI());		
+		Workbook book = manager.loadWorkbook(DocumentsCatalogue.prideTemplateEmptyWorkbookXLSXURI());
 		assertEquals(15,book.getSheets().size());
 		assertEquals("Introduction",book.getSheet(0).getName());
 		Collection<OntologyTermValidation> validations = parser.readOntologyTermValidations();
 		assertEquals(0,validations.size());
 	}
-	
+
 	@Test
 	public void testParseFreeTextPropertyValidationFromFile() throws Exception {
 		WorkbookManager manager = new WorkbookManager();
 		//parser is invoked during load, and then the validations are stripped out of the workbook, but stored by the ontologyTermManager
-		manager.loadWorkbook(DocumentsCatalogue.simpleWorkbookWithLiteralsOverRangeURI());		
+		manager.loadWorkbook(DocumentsCatalogue.simpleWorkbookWithLiteralsOverRangeURI());
 		Collection<OntologyTermValidation> validations = manager.getOntologyManager().getOntologyTermValidations();
-		
+
 		assertEquals(1,validations.size());
-		OntologyTermValidation v = validations.iterator().next();		
+		OntologyTermValidation v = validations.iterator().next();
 		assertEquals(new Range(manager.getWorkbook().getSheet(0),1,1,3,4),v.getRange());
 		assertEquals("http://www.w3.org/2002/07/owl#Nothing",v.getValidationDescriptor().getEntityIRI().toString());
 		assertEquals(ValidationType.FREETEXT,v.getValidationDescriptor().getType());
@@ -207,9 +212,9 @@ public class OntologyTermValidationWorkbookParserTest {
 		assertEquals(OWLPropertyType.DATA_PROPERTY,v.getValidationDescriptor().getOWLPropertyItem().getPropertyType());
 		assertEquals(1,v.getValidationDescriptor().getOntologyIRIs().size());
 		assertTrue(v.getValidationDescriptor().getOntologyIRIs().contains(IRI.create("http://www.mygrid.org.uk/ontology/JERMOntology")));
-		
+
 	}
-	
+
 	@Test
 	public void testClearOntologyTermValidations() throws Exception {
 		Collection<OntologyTermValidation> validations = createFreeTextValidations();
@@ -219,5 +224,5 @@ public class OntologyTermValidationWorkbookParserTest {
 		parser.clearOntologyTermValidations();
 		assertEquals(0,parser.readOntologyTermValidations().size());
 	}
-	
+
 }


### PR DESCRIPTION
Hi. Here I have added a button to filter the list of allowed values. This is because often not all terms are actually needed by the end user, so a filtered list is therefore nice to have.

The way I have approached this is by adding a `terms` variable to the `EntitySelectionModel`. This contains a filtered list of terms, or `null` when no filter is applied. As `OntologyTermValidationDescriptor` already contains a `terms` variable that is automatically populated by all terms on creation, I have now extended the constructor to allow a filtered list to be passed.

In terms of UI, I simpy added a button to the `ValidationValuesPanel` that opens a pop-up where the filtering can take place. At first I had added a checkbox to turn the filtering on or off (when off, `terms=null` in `EntitySelectionModel`). However there is no straightforward way to check if a range has been filtered. So the initial state of the checkbox is ambiguous.

One way to solve this is by adding this info somewhere in the exported file. Otherwise, on cell selection, I could load in all terms of the selected cell and do a comparison with the terms in the validation descriptor. If it is not equal, the checkbox should be on. Is that an idea?

This is my first time working on a Java project and contributing to another project, so feel free to tell me what can be improved and I will try my best to update it. :-) 